### PR TITLE
experiment: move from git bin to libgit

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -71,6 +71,7 @@ dependencies = [
  "env_logger",
  "fs_extra",
  "git-url-parse",
+ "git2",
  "insta",
  "lazy_static",
  "log",
@@ -705,6 +706,8 @@ dependencies = [
  "libc",
  "libgit2-sys",
  "log",
+ "openssl-probe",
+ "openssl-sys",
  "url",
 ]
 
@@ -943,8 +946,24 @@ checksum = "d0fa6563431ede25f5cc7f6d803c6afbc1c5d3ad3d4925d12c882bf2b526f5d1"
 dependencies = [
  "cc",
  "libc",
+ "libssh2-sys",
  "libz-sys",
+ "openssl-sys",
  "pkg-config",
+]
+
+[[package]]
+name = "libssh2-sys"
+version = "0.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b094a36eb4b8b8c8a7b4b8ae43b2944502be3e59cd87687595cf6b0a71b3f4ca"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "openssl-sys",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]

--- a/backpack/Cargo.toml
+++ b/backpack/Cargo.toml
@@ -42,6 +42,7 @@ walkdir = "2"
 serde_merge = "^0.1.2"
 dirs = "4"
 tracing = "^0.1.34"
+git2 = "^0.14.0"
 reqwest = { version = "^0.11.11", features = ["blocking"] }
 tracing-forest = { version = "^0.1.4" }
 tracing-subscriber = { version = "^0.3.11", features = ["env-filter"] }


### PR DESCRIPTION
* can only work for `ls-remote` (implemented here)
* there's no support in `libgit2` for shallow clone, and it's not getting there for the last few years (PRs exist, but no action), so it means we have to stay with the git binary anyways.